### PR TITLE
test: add xUnit test project with Moq and FluentAssertations

### DIFF
--- a/Backend-api/Noog-api/Noog-api.sln
+++ b/Backend-api/Noog-api/Noog-api.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.12.35527.113 d17.12
+VisualStudioVersion = 17.12.35527.113
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Noog-api", "Noog-api\Noog-api.csproj", "{87FD50E7-F23C-4702-8BA2-0756634ED164}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BackendApi.Tests", "..\..\Tests\BackendApi.Tests\BackendApi.Tests.csproj", "{C390D556-7956-4151-B97D-C933A61B0DCE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,8 +17,15 @@ Global
 		{87FD50E7-F23C-4702-8BA2-0756634ED164}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{87FD50E7-F23C-4702-8BA2-0756634ED164}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{87FD50E7-F23C-4702-8BA2-0756634ED164}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C390D556-7956-4151-B97D-C933A61B0DCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C390D556-7956-4151-B97D-C933A61B0DCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C390D556-7956-4151-B97D-C933A61B0DCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C390D556-7956-4151-B97D-C933A61B0DCE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {637400E0-F79F-4E83-A34C-F52ADFB6ED47}
 	EndGlobalSection
 EndGlobal

--- a/Tests/BackendApi.Tests/BackendApi.Tests.csproj
+++ b/Tests/BackendApi.Tests/BackendApi.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="8.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Backend-api\Noog-api\Noog-api\Noog-api.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/BackendApi.Tests/BackendApi.Tests.csproj
+++ b/Tests/BackendApi.Tests/BackendApi.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="8.7.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.5.3" />

--- a/Tests/BackendApi.Tests/UnitTest1.cs
+++ b/Tests/BackendApi.Tests/UnitTest1.cs
@@ -1,0 +1,11 @@
+namespace BackendApi.Tests
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
Initial xUnit test project for the Backend-api.

- Created `BackendApi.Tests` under `/Tests`
- Installed necessary NuGet packages: Moq, FluentAssertions
- Added project reference to `Backend-api`
- Verified test project builds and runs successfully



Closes #36 
Closes #37 